### PR TITLE
🐛 : Firebaseのセットアップができるように修正

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );


### PR DESCRIPTION
main() で `Firebase.initializeApp()` する前に `WidgetsFlutterBinding.ensureInitialized()` を追加しました。
[参考](https://qiita.com/kurun_pan/items/04f34a47cc8cee0fe542)