### PR TITLE
✨ : riverpodもつかってgo_routerを実装

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -2,6 +2,9 @@
 
 ## Firebase 関連
 
+| ライブラリ | 用途 |
+| ---------- | ---- |
+
 - firebase_core
 - firebase_auth
   - 認証に使用
@@ -11,4 +14,6 @@
 
 ## その他
 
-- go_router
+| ライブラリ                                      | 用途     |
+| ----------------------------------------------- | -------- |
+| [go_router](https://pub.dev/packages/go_router) | 画面遷移 |

--- a/lib/core/go_router.dart
+++ b/lib/core/go_router.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shopping_with_you/view/screen/sign_in_screen.dart';
+import 'package:shopping_with_you/view/screen/sign_up_screen.dart';
+
+/// go_routerのルーティング設定
+final routerProvier = Provider((ref) => GoRouter(
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) {
+            return SignInSceen();
+          },
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'signup',
+              builder: (BuildContext context, GoRouterState state) =>
+                  const SignUpScreen(),
+            )
+          ],
+        ),
+      ],
+    ));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:shopping_with_you/view/screen/sign_up_screen.dart';
+import 'package:shopping_with_you/core/go_router.dart';
 import 'firebase_options.dart';
 
 void main() async {
@@ -9,64 +10,27 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  runApp(const MyApp());
+  runApp(
+    const ProviderScope(
+      child: MyApp(),
+    ),
+  );
 }
 
-/// go_routerのルーティング設定
-final GoRouter _router = GoRouter(
-  routes: <RouteBase>[
-    GoRoute(
-      path: '/',
-      builder: (BuildContext context, GoRouterState state) {
-        return const HomeScreen();
-      },
-      routes: <RouteBase>[
-        GoRoute(
-          path: 'singup',
-          builder: (BuildContext context, GoRouterState state) {
-            return const SingUpScreen();
-          },
-        ),
-      ],
-    ),
-  ],
-);
-
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(routerProvier);
+
     return MaterialApp.router(
       theme: ThemeData(
         primarySwatch: Colors.orange,
       ),
-      routerConfig: _router,
-    );
-  }
-}
-
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('ふたりのお買い物'),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('サインアップ画面はこちらから'),
-            ElevatedButton(
-              onPressed: () => context.go('/singup'),
-              child: const Text('サインアップ画面'),
-            )
-          ],
-        ),
-      ),
+      // routerConfigでrouterDelegateやbackButtonDispatcherなどをまとめて設定してくれる
+      // NOTE: 今後ルーティングで課題が出たらrouterDelegateなどを個別設定する
+      routerConfig: router,
     );
   }
 }

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -1,0 +1,9 @@
+class User {
+  const User({
+    required this.email,
+    required this.password,
+  });
+
+  final String email;
+  final String password;
+}

--- a/lib/view/screen/sign_in_screen.dart
+++ b/lib/view/screen/sign_in_screen.dart
@@ -1,45 +1,50 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shopping_with_you/core/go_router.dart';
 import 'package:shopping_with_you/view/component/form_text_field.dart';
 
-class SingInSceen extends StatefulWidget {
-  const SingInSceen({super.key});
+class SignInSceen extends ConsumerWidget {
+  SignInSceen({super.key});
 
-  @override
-  State<SingInSceen> createState() => _SingInSceenState();
-}
-
-class _SingInSceenState extends State<SingInSceen> {
   final _formKey = GlobalKey<FormBuilderState>();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('ログイン'),
+        title: const Text('ふたりのお買い物'),
       ),
       body: Center(
-        child: FormBuilder(
-          key: _formKey,
-          child: Column(
-            children: [
-              FormTextField(
-                name: 'userName',
-                onChanged: (value) => _fieldOnChanged(value),
+        child: Column(
+          children: [
+            FormBuilder(
+              key: _formKey,
+              child: Column(
+                children: [
+                  FormTextField(
+                    name: 'userName',
+                    onChanged: (value) => _fieldOnChanged(value),
+                  ),
+                  FormTextField(
+                    name: 'password',
+                    onChanged: (value) => _fieldOnChanged(value),
+                    keyboardType: TextInputType.visiblePassword,
+                    obscureText: true,
+                  ),
+                  ElevatedButton(
+                    onPressed: () => _submit(),
+                    child: const Text('ログイン'),
+                  ),
+                ],
               ),
-              FormTextField(
-                name: 'password',
-                onChanged: (value) => _fieldOnChanged(value),
-                keyboardType: TextInputType.visiblePassword,
-                obscureText: true,
-              ),
-              ElevatedButton(
-                onPressed: _submit(),
-                child: const Text('サインアップ'),
-              ),
-            ],
-          ),
+            ),
+            TextButton(
+              child: const Text('ユーザー作成はこちらから'),
+              onPressed: () => ref.read(routerProvier).go('/signup'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/view/screen/sign_up_screen.dart
+++ b/lib/view/screen/sign_up_screen.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shopping_with_you/view/component/form_text_field.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-class SingUpScreen extends StatefulWidget {
-  const SingUpScreen({super.key});
+class SignUpScreen extends StatefulWidget {
+  const SignUpScreen({super.key});
 
   @override
-  State<SingUpScreen> createState() => _SingUpScreenState();
+  State<SignUpScreen> createState() => _SignUpScreenState();
 }
 
-class _SingUpScreenState extends State<SingUpScreen> {
+class _SignUpScreenState extends State<SignUpScreen> {
   final _formKey = GlobalKey<FormBuilderState>();
 
   @override
@@ -33,7 +34,7 @@ class _SingUpScreenState extends State<SingUpScreen> {
                 obscureText: true,
               ),
               ElevatedButton(
-                onPressed: _submit(),
+                onPressed: () => _submit(),
                 child: const Text('サインアップ'),
               ),
             ],
@@ -48,7 +49,7 @@ class _SingUpScreenState extends State<SingUpScreen> {
   }
 
   /// サインアップボタン用
-  _submit() async {
+  Future<void> _submit() async {
     debugPrint(_formKey.currentState?.value['userName']);
     debugPrint(_formKey.currentState?.value['password']);
     try {
@@ -56,6 +57,7 @@ class _SingUpScreenState extends State<SingUpScreen> {
         email: _formKey.currentState?.value['userName'],
         password: _formKey.currentState?.value['password'],
       );
+      context.go('/singup');
     } on FirebaseAuthException catch (e) {
       /// パスワードが弱い場合
       if (e.code == 'weak-password') {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,6 +158,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: b83ac5827baadefd331ea1d85110f34645827ea234ccabf53a655f41901a9bf4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -256,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "80e48bebc83010d5e67a11c9514af6b44bbac1ec77b4333c8ea65dbc79e2d8ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.6"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -277,6 +293,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: "8fe42610f179b843b12371e40db58c9444f8757f8b69d181c97e50787caed289"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2+1"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: ">=2.18.2 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -32,7 +32,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
@@ -41,6 +40,7 @@ dependencies:
   cloud_firestore: ^4.5.3
   go_router: ^7.0.0
   flutter_form_builder: ^8.0.0
+  flutter_riverpod: ^2.1.1
 
 dev_dependencies:
   flutter_test:
@@ -58,7 +58,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
go_routerをRiverpodを使用してProviderでラップする形で実装し、ルーティングを行なった。
ラップすることでgo_routerを呼び出しやすくなったり、多分だけど複雑な遷移の時（Notifier使う時とか）に便利になると思う。Notifireの中でBuildContext使わなくて済むし。

参考
- https://zenn.dev/flutteruniv_dev/articles/0657292b7b0962
- https://codewithandrea.com/articles/flutter-navigate-without-context-gorouter-riverpod/#3-navigate-without-context-using-refreadgorouterprovider
- https://www.sugitlab.dev/posts/go-router-with-riverpod